### PR TITLE
Small typo fix

### DIFF
--- a/basics/3/index.html
+++ b/basics/3/index.html
@@ -45,7 +45,7 @@
             <h1 id="basics-header">Distances for K-Buckets</h1>
             <div id="basics-content">
               <p>Each Kademlia node keeps a list of <i>n</i> <b>k-buckets</b>, where <i>n</i> is the number of bits in a key/node ID.</i></p>
-              <p>For <i>i</i> &lt;= 0 &lt; <i>n</i>, the <i>i</i>-th k-bucket for a node contains <b>up to <i>k</i> (IP address, UDP port, Node ID) triples for nodes of distance between 2<sup><i>i</i></sup> and 2<sup><i>i+1</i></sup> from itself</b>.</p>
+              <p>For 0 &lt;= <i>i</i> &lt; <i>n</i>, the <i>i</i>-th k-bucket for a node contains <b>up to <i>k</i> (IP address, UDP port, Node ID) triples for nodes of distance between 2<sup><i>i</i></sup> and 2<sup><i>i+1</i></sup> from itself</b>.</p>
               <p>In other words, the nodes in <code>originNode</code>'s <i>i</i>-th k-bucket have IDs such that <code>longestCommonPrefixLength(originNode.id, kbucketNode.id) = i</code>.</p>
             </div>
             <div id="instructions-container">


### PR DESCRIPTION
In the third page of basics the website states: `i <= 0 <= n` 
However, I believe this must be `0 <= i <= n` according to 2.2 of the Kademlia page.

On another note:
Thanks for the visualization, I only wish I found it earlier!